### PR TITLE
[CFDP-380] Moved the Events navigator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,11 @@
 // import hoistNonReactStatic from 'hoist-non-react-statics';
 import React from 'react';
-import { StatusBar } from 'react-native';
 import { createAppContainer, createStackNavigator } from 'react-navigation';
 import SplashScreen from 'react-native-splash-screen';
 
 import './icon-library';
 
-import { BackgroundView, withTheme } from '@apollosproject/ui-kit';
+import { BackgroundView } from '@apollosproject/ui-kit';
 import Passes from '@apollosproject/ui-passes';
 import { MediaPlayer } from '@apollosproject/ui-media-player';
 import Auth, { ProtectedRoute } from '@apollosproject/ui-auth';
@@ -22,7 +21,6 @@ import Login from './login';
 import { PrivacyPolicy, TermsOfUse, ValueProp } from './app-information';
 import { EditCurrentUserProfile } from './profile';
 import Settings from './settings';
-import Events from './tabs/more/events';
 
 const ProtectedRouteWithSplashScreen = (props) => {
   const handleOnRouteChange = () => SplashScreen.hide();
@@ -56,7 +54,6 @@ const AppInfo = createStackNavigator(
   },
   {
     initialRouteName: 'Settings',
-    // mode: 'modal',
     headerMode: 'screen',
   }
 );
@@ -76,20 +73,6 @@ const AppContentFeeds = createStackNavigator(
   }
 );
 
-const EventFeeds = createStackNavigator(
-  {
-    Events,
-  },
-  {
-    initialRouteName: 'Events',
-    // mode: 'modal',
-    headerMode: 'screen',
-    navigationOptions: {
-      gesturesEnabled: true,
-    },
-  }
-);
-
 const AppNavigator = createStackNavigator(
   {
     ProtectedRoute: ProtectedRouteWithSplashScreen,
@@ -97,7 +80,7 @@ const AppNavigator = createStackNavigator(
     LandingScreen: Login,
     AppInfo,
     AppContentFeeds,
-    EventFeeds,
+    // EventFeeds,
   },
   {
     initialRouteName: 'ProtectedRoute',

--- a/src/tabs/home/index.js
+++ b/src/tabs/home/index.js
@@ -2,11 +2,13 @@ import { createStackNavigator } from 'react-navigation';
 
 import tabBarIcon from '../tabBarIcon';
 
+import Events from '../more/events';
 import Home from './Home';
 
 export const HomeNavigator = createStackNavigator(
   {
     Home,
+    Events,
   },
   {
     initialRouteName: 'Home',

--- a/src/tabs/more/index.js
+++ b/src/tabs/more/index.js
@@ -7,7 +7,7 @@ import Events from './events';
 const MoreNavigator = createStackNavigator(
   {
     More,
-    // Events,
+    Events,
   },
   {
     initialRouteName: 'More',


### PR DESCRIPTION
Events now lives inside each of the navigators that require it (Home and More) so that it comes in from the side and doesn't reset the Tab Navigator every time you press into an Event for more detail