### PR TITLE
[Chat] Fix crash when media player state is not initialized

### DIFF
--- a/src/media-player/index.js
+++ b/src/media-player/index.js
@@ -43,7 +43,7 @@ const GET_LIVE_CONTENT = gql`
 `;
 
 const MediaPlayer = () => {
-  const { data } = useQuery(GET_MEDIA_PLAYER_VISIBILITY);
+  const { data = {} } = useQuery(GET_MEDIA_PLAYER_VISIBILITY);
 
   const { loading, data: liveData } = useQuery(GET_LIVE_CONTENT);
 


### PR DESCRIPTION
**Summary**

This PR fixes this crash.

<img width="400" src="https://user-images.githubusercontent.com/200488/91927860-9794e580-eca8-11ea-88be-941fb3f95433.png">

**Discussion**

It's crashing because the local media player state is empty. I'm not sure how it gets to be null, because the state is initialized by the media player here:

https://github.com/ApollosProject/apollos-apps/blob/c9e60b7efd9bd2c54e6b0d2ef2a1ef77d14c928a/packages/apollos-ui-media-player/src/Provider.js#L198

It may only occur on a fresh app install/login, but even then it should be initialized.

**Testing**

In brief testing, I could not reproduce this, but this defensive line should be in there anyway.


