### PR TITLE
Use checkInCurrentUser for attendance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ project.xcworkspace
 .env.development.local
 .env.test.local
 .env.production.local
+.bundle
 
 # CocoaPods
 /ios/Pods/

--- a/src/group-single/attendMeeting.js
+++ b/src/group-single/attendMeeting.js
@@ -2,8 +2,11 @@ import gql from 'graphql-tag';
 
 export default gql`
   mutation addAttendance($id: ID!) {
-    addMemberAttendance(id: $id) {
+    checkInCurrentUser(id: $id) {
       id
+      title
+      message
+      isCheckedIn
     }
   }
 `;


### PR DESCRIPTION
`addMemberAttendance` requires `locationIds` and will error if a group does not have a location/campus in Rock. So, quick fix is to use `checkInCurrentUser` and circle back later on a more robust solution for attendance