### PR TITLE
Patch Android Zoom bug when you background the app

### DIFF
--- a/patches/react-native-zoom-bridge+1.0.18.patch
+++ b/patches/react-native-zoom-bridge+1.0.18.patch
@@ -5,10 +5,10 @@ index 0000000..0d259dd
 +++ b/node_modules/react-native-zoom-bridge/android/build/.transforms/81b160fbb31a6a5821dea10aa018f88d.bin
 @@ -0,0 +1 @@
 +o/classes
-diff --git a/node_modules/react-native-zoom-bridge/android/build/.transforms/81b160fbb31a6a5821dea10aa018f88d/classes/classes.dex b/node_modules/react-native-zoom-bridge/android/build/.transforms/81b160fbb31a6a5821dea10aa018f88d/classes/classes.dex
-new file mode 100644
-index 0000000..e629dc2
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/.transforms/81b160fbb31a6a5821dea10aa018f88d/classes/classes.dex differ
+diff --git a/node_modules/react-native-zoom-bridge/android/libs/Put your downloaded aar's here b/node_modules/react-native-zoom-bridge/android/build/.transforms/81b160fbb31a6a5821dea10aa018f88d/classes/classes.dex
+similarity index 100%
+rename from node_modules/react-native-zoom-bridge/android/libs/Put your downloaded aar's here
+rename to node_modules/react-native-zoom-bridge/android/build/.transforms/81b160fbb31a6a5821dea10aa018f88d/classes/classes.dex
 diff --git a/node_modules/react-native-zoom-bridge/android/build/generated/source/buildConfig/debug/com/appgoalz/reactnative/BuildConfig.java b/node_modules/react-native-zoom-bridge/android/build/generated/source/buildConfig/debug/com/appgoalz/reactnative/BuildConfig.java
 new file mode 100644
 index 0000000..484b69b
@@ -67,14 +67,13 @@ index 0000000..9e26dfe
 @@ -0,0 +1 @@
 +{}
 \ No newline at end of file
-diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_library_classes/debug/classes.jar b/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_library_classes/debug/classes.jar
-new file mode 100644
-index 0000000..2db53a8
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_library_classes/debug/classes.jar differ
+diff --git a/node_modules/react-native-zoom-bridge/ios/libs/Put your downloaded sdk & bundle here b/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_library_classes/debug/classes.jar
+similarity index 100%
+rename from node_modules/react-native-zoom-bridge/ios/libs/Put your downloaded sdk & bundle here
+rename to node_modules/react-native-zoom-bridge/android/build/intermediates/compile_library_classes/debug/classes.jar
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_only_not_namespaced_r_class_jar/debug/R.jar b/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_only_not_namespaced_r_class_jar/debug/R.jar
 new file mode 100644
-index 0000000..546eaf2
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_only_not_namespaced_r_class_jar/debug/R.jar differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_symbol_list/debug/R.txt b/node_modules/react-native-zoom-bridge/android/build/intermediates/compile_symbol_list/debug/R.txt
 new file mode 100644
 index 0000000..6b8fbdf
@@ -11629,8 +11628,7 @@ index 0000000..6b8fbdf
 +int xml zm_restrictions 0x0
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/incremental/debug-mergeNativeLibs/merge-state b/node_modules/react-native-zoom-bridge/android/build/intermediates/incremental/debug-mergeNativeLibs/merge-state
 new file mode 100644
-index 0000000..4bb51a7
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/incremental/debug-mergeNativeLibs/merge-state differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/incremental/mergeDebugJniLibFolders/merger.xml b/node_modules/react-native-zoom-bridge/android/build/intermediates/incremental/mergeDebugJniLibFolders/merger.xml
 new file mode 100644
 index 0000000..1c7d1ff
@@ -11676,24 +11674,19 @@ index 0000000..1645310
 \ No newline at end of file
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/BuildConfig.class b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/BuildConfig.class
 new file mode 100644
-index 0000000..91e808d
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/BuildConfig.class differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgeModule$1.class b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgeModule$1.class
 new file mode 100644
-index 0000000..ad91ac1
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgeModule$1.class differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgeModule.class b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgeModule.class
 new file mode 100644
-index 0000000..8eb1912
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgeModule.class differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgePackage.class b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgePackage.class
 new file mode 100644
-index 0000000..649c978
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/javac/debug/classes/com/appgoalz/reactnative/RNZoomBridgePackage.class differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/library_java_res/debug/res.jar b/node_modules/react-native-zoom-bridge/android/build/intermediates/library_java_res/debug/res.jar
 new file mode 100644
-index 0000000..15cb0ec
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/library_java_res/debug/res.jar differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/library_manifest/debug/AndroidManifest.xml b/node_modules/react-native-zoom-bridge/android/build/intermediates/library_manifest/debug/AndroidManifest.xml
 new file mode 100644
 index 0000000..1305718
@@ -11757,8 +11750,7 @@ index 0000000..0637a08
 \ No newline at end of file
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/runtime_library_classes/debug/classes.jar b/node_modules/react-native-zoom-bridge/android/build/intermediates/runtime_library_classes/debug/classes.jar
 new file mode 100644
-index 0000000..3f67592
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/build/intermediates/runtime_library_classes/debug/classes.jar differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt b/node_modules/react-native-zoom-bridge/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt
 new file mode 100644
 index 0000000..06ce096
@@ -22376,9 +22368,6 @@ index 0000000..c21c47e
 +		INJECTED from /Users/jordanwade/code/di/christfellowship/apollos-app/node_modules/react-native-zoom-bridge/android/src/main/AndroidManifest.xml
 +		ADDED from /Users/jordanwade/code/di/christfellowship/apollos-app/node_modules/react-native-zoom-bridge/android/src/main/AndroidManifest.xml
 +		INJECTED from /Users/jordanwade/code/di/christfellowship/apollos-app/node_modules/react-native-zoom-bridge/android/src/main/AndroidManifest.xml
-diff --git a/node_modules/react-native-zoom-bridge/android/libs/Put your downloaded aar's here b/node_modules/react-native-zoom-bridge/android/libs/Put your downloaded aar's here
-deleted file mode 100644
-index e69de29..0000000
 diff --git a/node_modules/react-native-zoom-bridge/android/libs/commonlib.aar b/node_modules/react-native-zoom-bridge/android/libs/commonlib.aar
 new file mode 100644
 index 0000000..1463d1d
@@ -22387,10 +22376,57 @@ diff --git a/node_modules/react-native-zoom-bridge/android/libs/mobilertc.aar b/
 new file mode 100644
 index 0000000..6250429
 Binary files /dev/null and b/node_modules/react-native-zoom-bridge/android/libs/mobilertc.aar differ
+diff --git a/node_modules/react-native-zoom-bridge/android/src/main/java/com/appgoalz/reactnative/RNZoomBridgeModule.java b/node_modules/react-native-zoom-bridge/android/src/main/java/com/appgoalz/reactnative/RNZoomBridgeModule.java
+index fcf6937..a8cc553 100644
+--- a/node_modules/react-native-zoom-bridge/android/src/main/java/com/appgoalz/reactnative/RNZoomBridgeModule.java
++++ b/node_modules/react-native-zoom-bridge/android/src/main/java/com/appgoalz/reactnative/RNZoomBridgeModule.java
+@@ -139,6 +139,21 @@ public class RNZoomBridgeModule extends ReactContextBaseJavaModule implements Zo
+       }
+ 
+       final MeetingService meetingService = zoomSDK.getMeetingService();
++      if(meetingService.getMeetingStatus() != MeetingStatus.MEETING_STATUS_IDLE) {
++        long lMeetingNo = 0;
++        try {
++          lMeetingNo = Long.parseLong(meetingNo);
++        } catch (NumberFormatException e) {
++          promise.reject("ERR_ZOOM_START", "Invalid meeting number: " + meetingNo);
++          return;
++        }
++
++        if(meetingService.getCurrentRtcMeetingNumber() == lMeetingNo) {
++          meetingService.returnToMeeting(reactContext.getCurrentActivity());
++          promise.resolve("Already joined zoom meeting");
++          return;
++        }
++      }
+ 
+       JoinMeetingOptions opts = new JoinMeetingOptions();
+       JoinMeetingParams params = new JoinMeetingParams();
+@@ -173,6 +188,21 @@ public class RNZoomBridgeModule extends ReactContextBaseJavaModule implements Zo
+       }
+ 
+       final MeetingService meetingService = zoomSDK.getMeetingService();
++      if(meetingService.getMeetingStatus() != MeetingStatus.MEETING_STATUS_IDLE) {
++        long lMeetingNo = 0;
++        try {
++          lMeetingNo = Long.parseLong(meetingNo);
++        } catch (NumberFormatException e) {
++          promise.reject("ERR_ZOOM_START", "Invalid meeting number: " + meetingNo);
++          return;
++        }
++
++        if(meetingService.getCurrentRtcMeetingNumber() == lMeetingNo) {
++          meetingService.returnToMeeting(reactContext.getCurrentActivity());
++          promise.resolve("Already joined zoom meeting");
++          return;
++        }
++      }
+ 
+       JoinMeetingOptions opts = new JoinMeetingOptions();
+       JoinMeetingParams params = new JoinMeetingParams();
 diff --git a/node_modules/react-native-zoom-bridge/ios/.DS_Store b/node_modules/react-native-zoom-bridge/ios/.DS_Store
 new file mode 100644
-index 0000000..db385b3
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/ios/.DS_Store differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/ios/RNZoomBridge.xcodeproj/project.pbxproj b/node_modules/react-native-zoom-bridge/ios/RNZoomBridge.xcodeproj/project.pbxproj
 index afea5ed..5e4e9bc 100644
 --- a/node_modules/react-native-zoom-bridge/ios/RNZoomBridge.xcodeproj/project.pbxproj
@@ -22441,8 +22477,7 @@ index afea5ed..5e4e9bc 100644
  				PRODUCT_NAME = RNZoomBridge;
 diff --git a/node_modules/react-native-zoom-bridge/ios/RNZoomBridge.xcodeproj/project.xcworkspace/xcuserdata/jordanwade.xcuserdatad/UserInterfaceState.xcuserstate b/node_modules/react-native-zoom-bridge/ios/RNZoomBridge.xcodeproj/project.xcworkspace/xcuserdata/jordanwade.xcuserdatad/UserInterfaceState.xcuserstate
 new file mode 100644
-index 0000000..c4f0065
-Binary files /dev/null and b/node_modules/react-native-zoom-bridge/ios/RNZoomBridge.xcodeproj/project.xcworkspace/xcuserdata/jordanwade.xcuserdatad/UserInterfaceState.xcuserstate differ
+index 0000000..e69de29
 diff --git a/node_modules/react-native-zoom-bridge/ios/libs/MobileRTC.framework/Headers/MobileRTC.h b/node_modules/react-native-zoom-bridge/ios/libs/MobileRTC.framework/Headers/MobileRTC.h
 new file mode 100644
 index 0000000..5577fcf
@@ -47721,6 +47756,3 @@ diff --git a/node_modules/react-native-zoom-bridge/ios/libs/MobileRTCScreenShare
 new file mode 100644
 index 0000000..194379c
 Binary files /dev/null and b/node_modules/react-native-zoom-bridge/ios/libs/MobileRTCScreenShare.framework/MobileRTCScreenShare differ
-diff --git a/node_modules/react-native-zoom-bridge/ios/libs/Put your downloaded sdk & bundle here b/node_modules/react-native-zoom-bridge/ios/libs/Put your downloaded sdk & bundle here
-deleted file mode 100644
-index e69de29..0000000

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,12 +2959,12 @@
     "@octokit/types" "^5.0.0"
 
 "@octokit/endpoint@^6.0.1":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.5.tgz#43a6adee813c5ffd2f719e20cfd14a1fee7c193a"
-  integrity sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.6.tgz#4f09f2b468976b444742a1d5069f6fa45826d999"
+  integrity sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==
   dependencies:
     "@octokit/types" "^5.0.0"
-    is-plain-object "^4.0.0"
+    is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/plugin-enterprise-rest@^6.0.1":
@@ -3011,15 +3011,15 @@
     once "^1.4.0"
 
 "@octokit/request@^5.2.0":
-  version "5.4.7"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.7.tgz#fd703ee092e0463ceba49ff7a3e61cb4cf8a0fde"
-  integrity sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==
+  version "5.4.8"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.8.tgz#13ad36e172bb57e78bacf02cd86210d1f7412f04"
+  integrity sha512-mWbxjsARJzAq5xp+ZrQfotc+MHFz3/Am2qATJwflv4PZ1TjhgIJnr60PCVdZT9Z/tl+uPXooaVgeviy1KkDlLQ==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.0.0"
     "@octokit/types" "^5.0.0"
     deprecation "^2.0.0"
-    is-plain-object "^4.0.0"
+    is-plain-object "^5.0.0"
     node-fetch "^2.3.0"
     once "^1.4.0"
     universal-user-agent "^6.0.0"
@@ -3868,9 +3868,9 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
-  version "7.0.13"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.13.tgz#1874914be974a492e1b4cb00585cabb274e8ba18"
-  integrity sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==
+  version "7.0.14"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.14.tgz#e99da8c075d4fb098c774ba65dabf7dc9954bd13"
+  integrity sha512-8w9szzKs14ZtBVuP6Wn7nMLRJ0D6dfB0VEBEyRgxrZ/Ln49aNMykrghM2FaNn4FJRzNppCSa0Rv9pBRM5Xc3wg==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -3979,19 +3979,19 @@
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/node@*", "@types/node@>= 8", "@types/node@>=6":
-  version "14.6.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.4.tgz#a145cc0bb14ef9c4777361b7bbafa5cf8e3acb5a"
-  integrity sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ==
+  version "14.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
+  integrity sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==
 
 "@types/node@^10.11.7":
-  version "10.17.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.29.tgz#263b7013f9f4afa53585b199f9a4255d9613b178"
-  integrity sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA==
+  version "10.17.32"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.32.tgz#4ef6ff8b842ea0eb3fcbc4331489f4ae64036fa8"
+  integrity sha512-EUq+cjH/3KCzQHikGnNbWAGe548IFLSm93Vl8xA7EuYEEATiyOVDyEVuGkowL7c9V69FF/RiZSAOCFPApMs/ig==
 
 "@types/node@^13.7.0":
-  version "13.13.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.16.tgz#66f2177047b61131eaac18c47eb25d6f1317070a"
-  integrity sha512-dJ9vXxJ8MEwzNn4GkoAGauejhXoKuJyYKegsA6Af25ZpEDXomeVXt5HUWUNVHk5UN7+U0f6ghC6otwt+7PdSDg==
+  version "13.13.19"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.19.tgz#f4165496e66e3da37b9e136887db446795e00c5b"
+  integrity sha512-IVsULCpTdafcHhBDLYEPnV5l15xV0q065zvOHC1ZmzFYaBCMzku078eXnazoSG8907vZjRgEN/EQjku7GwwFyQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4024,9 +4024,9 @@
     "@types/react" "*"
 
 "@types/react-native@*":
-  version "0.63.15"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.15.tgz#f86ce87a0afc53bec7c6bc96282e698e0a03ce1b"
-  integrity sha512-ZFOHFn4NNKxvpHfri099KMVCeHU9Rvu7E3GC6ST1KGoktipyfWTW0HLePKAflbmARODAh84ci4HSzAXnW54FXw==
+  version "0.63.18"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.18.tgz#748d82c6453befe97285393ad9530472d8de56af"
+  integrity sha512-WwEWqmHiqFn61M1FZR/+frj+E8e2o8i5cPqu9mjbjtZS/gBfCKVESF2ai/KAlaQECkkWkx/nMJeCc5eHMmLQgw==
   dependencies:
     "@types/react" "*"
 
@@ -4121,9 +4121,9 @@
     "@types/yargs-parser" "*"
 
 "@types/zen-observable@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
-  integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.1.tgz#5668c0bce55a91f2b9566b1d8a4c0a8dbbc79764"
+  integrity sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -4318,9 +4318,9 @@ JSONStream@^1.0.4, JSONStream@^1.3.4:
     through ">=2.2.7 <3"
 
 abab@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.4.tgz#6dfa57b417ca06d21b2478f0e638302f99c2405c"
-  integrity sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
 abbrev@1:
   version "1.1.1"
@@ -6279,9 +6279,9 @@ bluebird@^3.3.5, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 blueimp-md5@^2.10.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.17.0.tgz#f4fcac088b115f7b4045f19f5da59e9d01b1bb96"
-  integrity sha512-x5PKJHY5rHQYaADj6NwPUR2QRCUVSggPzrUKkeENpj871o9l9IefJbO2jkT5UvYykeOK9dx0VmkIo6dZ+vThYw==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/blueimp-md5/-/blueimp-md5-2.18.0.tgz#1152be1335f0c6b3911ed9e36db54f3e6ac52935"
+  integrity sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q==
 
 bmp-js@^0.1.0:
   version "0.1.0"
@@ -6500,14 +6500,14 @@ browserslist@^3.2.6:
     electron-to-chromium "^1.3.47"
 
 browserslist@^4.12.0, browserslist@^4.4.2, browserslist@^4.8.5:
-  version "4.14.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.1.tgz#cb2b490ba881d45dc3039078c7ed04411eaf3fa3"
-  integrity sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==
+  version "4.14.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.2.tgz#1b3cec458a1ba87588cc5e9be62f19b6d48813ce"
+  integrity sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==
   dependencies:
-    caniuse-lite "^1.0.30001124"
-    electron-to-chromium "^1.3.562"
+    caniuse-lite "^1.0.30001125"
+    electron-to-chromium "^1.3.564"
     escalade "^3.0.2"
-    node-releases "^1.1.60"
+    node-releases "^1.1.61"
 
 bser@2.1.1:
   version "2.1.1"
@@ -6759,10 +6759,10 @@ can-use-dom@^0.1.0:
   resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
   integrity sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=
 
-caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000884, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001124:
-  version "1.0.30001124"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz#5d9998190258e11630d674fc50ea8e579ae0ced2"
-  integrity sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000884, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125:
+  version "1.0.30001125"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz#2a1a51ee045a0a2207474b086f628c34725e997b"
+  integrity sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -8244,9 +8244,9 @@ dot-prop@^4.2.0, dot-prop@^4.2.1:
     is-obj "^1.0.0"
 
 dot-prop@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
-  integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
+  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
 
@@ -8339,10 +8339,10 @@ ejs@^2.6.1:
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.7.4.tgz#48661287573dcc53e366c7a1ae52c3a120eec9ba"
   integrity sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
 
-electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.562, electron-to-chromium@^1.3.62:
-  version "1.3.562"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz#79c20277ee1c8d0173a22af00e38433b752bc70f"
-  integrity sha512-WhRe6liQ2q/w1MZc8mD8INkenHivuHdrr4r5EQHNomy3NJux+incP6M6lDMd0paShP3MD0WGe5R1TWmEClf+Bg==
+electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.62:
+  version "1.3.566"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.566.tgz#e373876bb63e5c9bbcbe1b48cbb2db000f79bf88"
+  integrity sha512-V0fANdGN7waOE0tvCDhjf1vqPRevG3eo0asYm42c4t1qmZSunlnUuWQDxglUi9wDpbKQlGIttMJ+2DYpRwvYRA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -8750,9 +8750,9 @@ eslint-plugin-prettier@^2.6.0:
     jest-docblock "^21.0.0"
 
 eslint-plugin-react-hooks@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.0.tgz#6323fbd5e650e84b2987ba76370523a60f4e7925"
-  integrity sha512-36zilUcDwDReiORXmcmTc6rRumu9JIM3WjSvV0nclHoUQ0CNrX866EwONvLR/UqaeqFutbAnVu8PEmctdo2SRQ==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.2.tgz#2eb53731d11c95826ef7a7272303eabb5c9a271e"
+  integrity sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
@@ -10235,7 +10235,7 @@ has-symbol-support-x@^1.4.1:
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
   integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
+has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -10965,9 +10965,9 @@ is-buffer@^2.0.2:
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
-  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.1.tgz#4d1e21a4f437509d25ce55f8184350771421c96d"
+  integrity sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==
 
 is-ci@^1.0.10:
   version "1.2.1"
@@ -11199,10 +11199,10 @@ is-plain-object@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
   integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
 
-is-plain-object@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-4.1.1.tgz#1a14d6452cbd50790edc7fdaa0aed5a40a35ebb5"
-  integrity sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-promise@^2.1.0:
   version "2.2.2"
@@ -13571,9 +13571,9 @@ node-fetch@^1.0.1:
     is-stream "^1.0.1"
 
 node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-gyp@^5.0.2:
   version "5.1.1"
@@ -13642,10 +13642,10 @@ node-notifier@^5.2.1, node-notifier@^5.4.2:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-releases@^1.0.0-alpha.11, node-releases@^1.1.60:
-  version "1.1.60"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.60.tgz#6948bdfce8286f0b5d0e5a88e8384e954dfe7084"
-  integrity sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==
+node-releases@^1.0.0-alpha.11, node-releases@^1.1.61:
+  version "1.1.61"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.61.tgz#707b0fca9ce4e11783612ba4a2fcba09047af16e"
+  integrity sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==
 
 node-version@^1.0.0:
   version "1.2.0"
@@ -13884,7 +13884,7 @@ object-is@^1.0.1:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"
 
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -13897,14 +13897,14 @@ object-visit@^1.0.0:
     isobject "^3.0.0"
 
 object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.entries@^1.1.0, object.entries@^1.1.2:
   version "1.1.2"
@@ -15683,9 +15683,9 @@ react-native-webview@^5.2.0:
     invariant "2.2.4"
 
 react-native-windows@^0.62.0-0:
-  version "0.62.7"
-  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.62.7.tgz#f527b2a42a869b0d80af1fbb6d55051904253175"
-  integrity sha512-Y46FUBSwBh3rfLD7lTlshb9P040V3ZaBpm2MrB6UziE3YnXK4NwvcdpmQd3LJZWMjUvklSJBzU1z34xTB1yETQ==
+  version "0.62.9"
+  resolved "https://registry.yarnpkg.com/react-native-windows/-/react-native-windows-0.62.9.tgz#08669e95ac1cb859845dd42ae3160cc040f0404b"
+  integrity sha512-6JtjWs5js1K/3cetMl4IQMCRHYCPKzwO0HRbVL16gBz5uP0YvlZKyvZnbZaHpAJ2UymfqtIyrE9Ahi/PnVGp1g==
   dependencies:
     "@babel/runtime" "^7.8.4"
     cli-spinners "^2.2.0"
@@ -16604,9 +16604,9 @@ rxjs@^5.4.3:
     symbol-observable "1.0.1"
 
 rxjs@^6.1.0, rxjs@^6.3.3, rxjs@^6.4.0:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
-  integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -18148,9 +18148,9 @@ uglify-es@^3.1.9:
     source-map "~0.6.1"
 
 uglify-js@^3.1.4:
-  version "3.10.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.3.tgz#f0d2f99736c14de46d2d24649ba328be3e71c3bf"
-  integrity sha512-Lh00i69Uf6G74mvYpHCI9KVVXLcHW/xu79YTvH7Mkc9zyKUeSPz0owW0dguj0Scavns3ZOh3wY63J0Zb97Za2g==
+  version "3.10.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.4.tgz#dd680f5687bc0d7a93b14a3482d16db6eba2bfbb"
+  integrity sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw==
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -18668,9 +18668,9 @@ whatwg-fetch@2.0.4:
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz#e11de14f4878f773fbebcde8871b2c0699af8b30"
-  integrity sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
When you switch to your home screen on Android and go back into the App, click 'Join Meeting' and you should be back in the meeting with no errors.

After you yarn, search for `meetingService.returnToMeeting` in the `react-native-zoom-bridge` node_module and it should be in the `RNZoomBridgeModule.java` three times. Specifically, in the `joinMeetingWithPassword` and `joinMeeting` is where we want to see that method called. This is the code that should be added to those methods by the patch.

```
      if(meetingService.getMeetingStatus() != MeetingStatus.MEETING_STATUS_IDLE) {
        long lMeetingNo = 0;
        try {
          lMeetingNo = Long.parseLong(meetingNo);
        } catch (NumberFormatException e) {
          promise.reject("ERR_ZOOM_START", "Invalid meeting number: " + meetingNo);
          return;
        }

        if(meetingService.getCurrentRtcMeetingNumber() == lMeetingNo) {
          meetingService.returnToMeeting(reactContext.getCurrentActivity());
          promise.resolve("Already joined zoom meeting");
          return;
        }
      }
``` 