### PR TITLE
[Chat] Chat Channel ID and Event Metadata

### DIFF
--- a/ios/ChristFellowship.xcodeproj/project.pbxproj
+++ b/ios/ChristFellowship.xcodeproj/project.pbxproj
@@ -533,6 +533,7 @@
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ChristFellowship/Pods-ChristFellowship-resources.sh",
 				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTC.framework",
+				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTCScreenShare.framework",
 				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTCResources.bundle",
 				"${PODS_ROOT}/google-cast-sdk-no-bluetooth/GoogleCastSDK-ios-4.4.7_static/GoogleCast.framework/GoogleCastCoreResources.bundle",
 				"${PODS_ROOT}/google-cast-sdk-no-bluetooth/GoogleCastSDK-ios-4.4.7_static/GoogleCast.framework/GoogleCastUIResources.bundle",
@@ -540,6 +541,7 @@
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTC.framework",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTCScreenShare.framework",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTCResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleCastCoreResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleCastUIResources.bundle",

--- a/src/media-player/LiveStreamChat.js
+++ b/src/media-player/LiveStreamChat.js
@@ -35,7 +35,7 @@ const LiveStreamChat = (props) => {
   const [fetchRole] = useLazyQuery(GET_CURRENT_USER_ROLE_FOR_CHANNEL, {
     fetchPolicy: 'network-only',
     variables: {
-      channelId: props.contentId,
+      channelId: props.channelId,
     },
   });
 
@@ -89,7 +89,11 @@ const LiveStreamChat = (props) => {
         );
       }
 
-      channel.current = chatClient.channel('livestream', props.contentId);
+      channel.current = chatClient.channel(
+        'livestream',
+        props.channelId,
+        props.event
+      );
 
       await channel.current.create();
       // await channel.current.watch();
@@ -161,7 +165,13 @@ const LiveStreamChat = (props) => {
 
 LiveStreamChat.propTypes = {
   isPortrait: PropTypes.bool,
-  contentId: PropTypes.string,
+  channelId: PropTypes.string,
+  event: PropTypes.shape({
+    parentId: PropTypes.string,
+    name: PropTypes.string,
+    startsAt: PropTypes.string,
+    endsAt: PropTypes.string,
+  }),
   onChannelsUpdated: PropTypes.func,
 };
 

--- a/src/media-player/LiveStreamPlayer.js
+++ b/src/media-player/LiveStreamPlayer.js
@@ -133,7 +133,13 @@ class LiveStreamPlayer extends PureComponent {
   // eslint-disable-next-line react/sort-comp
   static propTypes = {
     client: PropTypes.shape({ mutate: PropTypes.func }),
-    contentId: PropTypes.string,
+    channelId: PropTypes.string,
+    event: PropTypes.shape({
+      parentId: PropTypes.string,
+      name: PropTypes.string,
+      startsAt: PropTypes.string,
+      endsAt: PropTypes.string,
+    }),
   };
 
   state = { portrait: true, channels: [] };
@@ -423,7 +429,8 @@ class LiveStreamPlayer extends PureComponent {
             >
               <LiveStreamChat
                 isPortrait={this.state.portrait}
-                contentId={this.props.contentId}
+                channelId={this.props.channelId}
+                event={this.props.event}
               />
             </Animated.View>
           </PlayerContext.Provider>

--- a/src/media-player/index.js
+++ b/src/media-player/index.js
@@ -37,7 +37,16 @@ const GET_LIVE_CONTENT = gql`
       }
       contentItem {
         id
+        title
+        ... on EventContentItem {
+          events {
+            id
+            start
+            end
+          }
+        }
       }
+      chatChannelId
     }
   }
 `;
@@ -55,14 +64,20 @@ const MediaPlayer = () => {
 
   if (loading) return null;
 
-  const livestreams = get(liveData, 'liveStreams', []).filter((s) => s.isLive);
-  const livestream = livestreams.find(
+  const liveStreams = get(liveData, 'liveStreams', []).filter((s) => s.isLive);
+  const liveStream = liveStreams.find(
     (l) => uri === get(l, 'media.sources[0].uri')
   );
-  const contentId = get(livestream, 'contentItem.id', '').split(':')[1];
+  const channelId = get(liveStream, 'chatChannelId');
 
-  if (enabled && livestream) {
-    return <LiveStreamPlayer contentId={contentId} />;
+  if (enabled && liveStream) {
+    const event = {
+      parentId: get(liveStream, 'contentItem.id'),
+      name: get(liveStream, 'contentItem.title'),
+      startsAt: get(liveStream, 'contentItem.events[0].start'),
+      endsAt: get(liveStream, 'contentItem.events[0].end'),
+    };
+    return <LiveStreamPlayer channelId={channelId} event={event} />;
   }
 
   return <FullscreenPlayer />;


### PR DESCRIPTION
**Summary**

This PR wires up the client to use the new `chatChannelId` field on the API when creating a channel for a livestream event.

Secondarily, it also inserts event metadata into the channel at creation time. This is not totally necessary at this time, but will be handy in the future should we ever wish to query, render, filter, debug, etc channels via the Stream CLI or otherwise. The metadata is:

- Parent ID (`EventContentItem:1e07e4f2e1b52807e43b2338c73d88ba`)
- Parent title (`Test 24 Hour Live Stream`)
- Event start time (`2020-09-24T04:00:00.000Z`)
- Event end time (`2020-09-25T04:00:00.000Z`)


**Discussion**

**Testing**

Make sure you are running https://github.com/christfellowshipchurch/apollos-api/pull/134 either in master or checked out.

Run this query in Playground.

```gql
query getLiveContent {
  liveStreams {
    isLive
    media {
      sources {
        uri
      }
    }
    chatChannelId
    contentItem {
      id
      title
      ... on EventContentItem {
        events {
          id
          start
          end
          name
        }
      }
    }
  }
}
```

Note the `chatChannelId`.


Open the livestream chat to create a channel.

In the terminal, run this command. Ensure that the ID portion of the channel ID (`cid`) matches what is returned by the API.

```bash
$ npx stream chat:channel:query --filter '{"type": "livestream"}'  | grep cid
```






**Screenshots**
