### PR TITLE
Pass video call link if no meeting id exists

### DIFF
--- a/src/group-single/VideoCall.js
+++ b/src/group-single/VideoCall.js
@@ -9,7 +9,7 @@ import moment from 'moment';
 import { useMutation } from '@apollo/react-hooks';
 import { styled, Button } from '@apollosproject/ui-kit';
 
-import { useCurrentUser } from '../hooks';
+import { useCurrentUser, useLinkRouter } from '../hooks';
 
 import ATTEND_MEETING from './attendMeeting';
 
@@ -58,6 +58,7 @@ const VideoCall = ({
   }, []);
 
   const { firstName, nickName } = useCurrentUser();
+  const { routeLink } = useLinkRouter();
   const name = nickName || firstName;
 
   const [handleAttend, { loading: mutationLoading }] = useMutation(
@@ -115,7 +116,13 @@ const VideoCall = ({
         <CellItem first>
           <Button
             onPress={() =>
-              join(parentVideoCall.meetingId, parentVideoCall.passcode, groupId)
+              parentVideoCall.meetingId
+                ? join(
+                    parentVideoCall.meetingId,
+                    parentVideoCall.passcode,
+                    groupId
+                  )
+                : routeLink(parentVideoCall.link)
             }
             loading={isLoading || mutationLoading}
             title={parentVideoCall.labelText || 'Join Meeting'}
@@ -128,7 +135,9 @@ const VideoCall = ({
         <CellItem>
           <Button
             onPress={() =>
-              join(videoCall.meetingId, videoCall.passcode, groupId)
+              videoCall.meetingId
+                ? join(videoCall.meetingId, videoCall.passcode, groupId)
+                : routeLink(videoCall.link)
             }
             loading={isLoading}
             title={
@@ -146,14 +155,16 @@ const VideoCall = ({
 
 VideoCall.propTypes = {
   parentVideoCall: PropTypes.shape({
+    labelText: PropTypes.string,
+    link: PropTypes.string,
     meetingId: PropTypes.string,
     passcode: PropTypes.string,
-    labelText: PropTypes.string,
   }),
   videoCall: PropTypes.shape({
+    labelText: PropTypes.string,
+    link: PropTypes.string,
     meetingId: PropTypes.string,
     passcode: PropTypes.string,
-    labelText: PropTypes.string,
   }),
   groupId: PropTypes.string,
   isLoading: PropTypes.bool,


### PR DESCRIPTION
Makes it so a group can pass in anything to the `video call link` param in Rock and it will be passed to the `onPress` of the video call button if the video call object does not have a `meetingId`.
![2020-09-29 12 45 13](https://user-images.githubusercontent.com/2528817/94597065-b27c5a80-0252-11eb-8aa2-e8f2dab6a658.gif)
![2020-09-29 12 50 16](https://user-images.githubusercontent.com/2528817/94597076-b7410e80-0252-11eb-8e8e-b2f7a5b0e186.gif)
