### PR TITLE
[Live] Add upcoming to calendar app

### DIFF
--- a/src/content-single/AddCalEventButton/index.js
+++ b/src/content-single/AddCalEventButton/index.js
@@ -3,23 +3,20 @@ import { presentEventCreatingDialog } from 'react-native-add-calendar-event';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-import {
-  Button,
-  BodySmall,
-  Icon,
-  withTheme,
-  styled,
-} from '@apollosproject/ui-kit';
+import { Button, BodySmall, Icon, withTheme } from '@apollosproject/ui-kit';
 
-const StyledButton = withTheme(({ theme }) => ({
+const StyledButton = withTheme(({ size, theme }) => ({
   style: {
     alignSelf: 'flex-end',
-    height: theme.sizing.baseUnit * 2,
+    height: size || theme.sizing.baseUnit * 2,
   },
 }))(Button);
 
-const StyledIcon = styled(({ theme }) => ({
-  marginRight: theme.sizing.baseUnit * 0.5,
+const StyledIcon = withTheme(({ size, theme }) => ({
+  size: (size || theme.sizing.baseUnit * 2) * 0.4375,
+  style: {
+    marginRight: theme.sizing.baseUnit * 0.5,
+  },
 }))(Icon);
 
 const utcDateToString = (momentInUTC) => {
@@ -57,6 +54,8 @@ const AddCalEventButton = ({
   eventNotes,
   isLoading,
   disabled,
+  buttonLabel = 'Add to Calendar',
+  size = null,
 }) => (
   <StyledButton
     disabled={disabled || isLoading}
@@ -66,9 +65,10 @@ const AddCalEventButton = ({
     }}
     bordered
     type={'primary'}
+    size={size}
   >
-    <StyledIcon name="calendar-add" size={14} />
-    <BodySmall>Add to Calendar</BodySmall>
+    <StyledIcon name="calendar-add" size={size} />
+    <BodySmall>{buttonLabel}</BodySmall>
   </StyledButton>
 );
 
@@ -78,6 +78,8 @@ AddCalEventButton.propTypes = {
   eventNotes: PropTypes.string,
   isLoading: PropTypes.bool,
   disabled: PropTypes.bool,
+  buttonLabel: PropTypes.string,
+  size: PropTypes.number,
 };
 
 export default AddCalEventButton;

--- a/src/content-single/EventContentItem/index.js
+++ b/src/content-single/EventContentItem/index.js
@@ -126,7 +126,7 @@ const EventContentItem = ({ content, loading }) => {
 
                     {events.length > 0 && (
                       <EventDateTimes
-                        contentId={content.id}
+                        content={content}
                         events={content.events}
                         loading={loading}
                       />

--- a/src/content-single/EventDateTimes/index.js
+++ b/src/content-single/EventDateTimes/index.js
@@ -4,10 +4,24 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 
 import { BodyText, Icon, styled, withTheme } from '@apollosproject/ui-kit';
+import AddCalEventButton from '../AddCalEventButton';
 
-const Row = styled(({ theme, fontWeight }) => ({
-  marginVertical: theme.sizing.baseUnit * 0.5,
+const Container = styled(({ theme }) => ({
+  marginBottom: theme.sizing.baseUnit,
 }))(View);
+
+const Row = styled(({ theme }) => ({
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: theme.sizing.baseUnit,
+}))(View);
+
+const Cell = styled({
+  flexDirection: 'row',
+  alignItems: 'center',
+  flexWrap: 'nowrap',
+})(View);
 
 const StyledText = styled(({ theme, fontWeight }) => ({
   fontSize: 20,
@@ -20,49 +34,46 @@ const StyledIcon = withTheme(({ theme }) => ({
   fill: theme.colors.text.tertiary,
 }))(Icon);
 
-const TextIconRow = ({ icon, fontWeight, children }) => (
-  <View
-    style={{
-      flexDirection: 'row',
-      justifyContent: 'flex-start',
-      alignItems: 'center',
-    }}
-  >
-    <StyledIcon name={icon} />
-    <StyledText style={{ fontWeight }}>{children}</StyledText>
-  </View>
-);
-
-const DateTime = ({ start }) => {
+const DateTime = ({ title, summary, start }) => {
   const mDate = moment(start);
 
   return (
     <Row>
-      <TextIconRow icon="calendar" fontSize={20} fontWeight="bold">
-        {mDate.format('ddd MMM D')}
-      </TextIconRow>
-      <TextIconRow icon="clock" fontSize={20}>
-        {mDate.format('LT')}
-      </TextIconRow>
+      <Cell>
+        <StyledIcon name={'calendar'} />
+        <StyledText fontWeight={'bold'}>{mDate.format('ddd MMM D')}</StyledText>
+        <StyledText>{mDate.format('LT')}</StyledText>
+      </Cell>
+      <AddCalEventButton
+        eventNotes={summary}
+        eventStart={start}
+        eventTitle={title}
+        buttonLabel={'Add'}
+        size={24}
+      />
     </Row>
   );
 };
 
-const EventDateTimes = ({ events, loading }) => {
+const EventDateTimes = ({ content, events, loading }) => {
   if (loading || events.length === 0) return null;
 
   return (
-    <Row>
+    <Container>
       {events
         .sort((a, b) => moment(a.start).diff(moment(b.start)))
-        .map((event, i) => (
-          <DateTime key={`EventDateTime:${i}`} {...event} />
+        .map((event) => (
+          <DateTime key={event.start} {...content} {...event} />
         ))}
-    </Row>
+    </Container>
   );
 };
 
 EventDateTimes.propTypes = {
+  content: PropTypes.shape({
+    title: PropTypes.string,
+    summary: PropTypes.string,
+  }),
   events: PropTypes.arrayOf(PropTypes.object),
   loading: PropTypes.bool,
 };


### PR DESCRIPTION
### Summary

This PR modifies the Livestream event page to allow the user to add an upcoming livestream to their calendar app. Borrows heavily from the Groups add-to-calendar button.

### Discussion

I went back and forth with the layout, but ultimately landed on what  you see below.

### Testing

From the Home tab, open up the `Tune In Online` event. Pressing on any of the upcoming livestreams should open the add-to-calendar UI with the correct data filled in.

### Screenshots

<img width="300" src="https://user-images.githubusercontent.com/200488/94622001-5a0f8200-027f-11eb-9faa-f8af23bb4e79.gif">
