### PR TITLE
[Events] Hide Events Schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "codecov": "cat ./coverage/lcov.info | codecov",
     "fixlint": "eslint ./src --fix",
     "generate-stories": "rnstl --searchDir ./src --pattern **/*.stories.js",
-    "ios": "react-native run-ios --simulator=\"iPhone X\"",
+    "ios": "react-native run-ios --simulator=\"iPhone 11\"",
     "link-packages": "yarn --check-files --ignore-scripts && node ./scripts/link-packages",
     "unlink-packages": "rm -rf ./node_modules/@apollosproject/* && ../node_modules/.bin/wml rm all",
     "lint": "eslint ./src --ext .js",

--- a/src/content-single/EventContentItem/index.js
+++ b/src/content-single/EventContentItem/index.js
@@ -124,13 +124,13 @@ const EventContentItem = ({ content, loading }) => {
                         </H4>
                       )}
 
-                    {events.length > 0 && (
+                    {/* {events.length > 0 && (
                       <EventDateTimes
                         content={content}
                         events={content.events}
                         loading={loading}
                       />
-                    )}
+                    )} */}
 
                     {callsToAction.length > 0 &&
                       callsToAction.map((n) => (


### PR DESCRIPTION
Temporarily hides the schedule info on an Event until we land the plane on the schema updates and scheduling setup.

<img src="https://user-images.githubusercontent.com/1812955/95369949-167fce00-08a6-11eb-9d89-0c7614347a6c.jpg" width="300" />