### PR TITLE
Setup Live Stream Interactions

### DIFF
--- a/src/content-single/ContentSingle.js
+++ b/src/content-single/ContentSingle.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 
 import { ErrorCard } from '@apollosproject/ui-kit';
 import { TrackEventWhenLoaded } from '@apollosproject/ui-analytics';
+import { InteractWhenLoadedConnected } from '@apollosproject/ui-connected';
 import ThemeMixin from '../ui/DynamicThemeMixin';
 
 import ActionContainer from './ActionContainer';
@@ -104,6 +105,11 @@ class ContentSingle extends PureComponent {
 
     return (
       <ThemeMixin theme={theme}>
+        <InteractWhenLoadedConnected
+          isLoading={loading}
+          nodeId={this.itemId}
+          action={'COMPLETE'}
+        />
         <TrackEventWhenLoaded
           loaded={!!(!loading && content.title)}
           eventName={'View Content'}

--- a/src/media-player/LiveStreamPlayer.js
+++ b/src/media-player/LiveStreamPlayer.js
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { Query, withApollo } from 'react-apollo';
+import { InteractWhenLoadedConnected } from '@apollosproject/ui-connected';
 import { get } from 'lodash';
 
 import {
@@ -140,6 +141,7 @@ class LiveStreamPlayer extends PureComponent {
       startsAt: PropTypes.string,
       endsAt: PropTypes.string,
     }),
+    isLoading: PropTypes.bool,
   };
 
   state = {
@@ -371,6 +373,7 @@ class LiveStreamPlayer extends PureComponent {
   };
 
   renderLiveStream = ({ mediaPlayer }) => {
+    console.log('LIVESTREAM LODDED');
     const { isFullscreen = false, isCasting = false } = mediaPlayer;
     return (
       <LiveStreamContainer
@@ -465,7 +468,7 @@ class LiveStreamPlayer extends PureComponent {
           style={this.miniControlsAnimation}
           onLayout={this.handleMiniControlLayout}
         >
-          <MiniControls />
+          <MiniControls nodeId={this.props.event.parentId} isLiveStream />
         </Animated.View>
       );
     }

--- a/src/media-player/LiveStreamPlayer.js
+++ b/src/media-player/LiveStreamPlayer.js
@@ -373,7 +373,6 @@ class LiveStreamPlayer extends PureComponent {
   };
 
   renderLiveStream = ({ mediaPlayer }) => {
-    console.log('LIVESTREAM LODDED');
     const { isFullscreen = false, isCasting = false } = mediaPlayer;
     return (
       <LiveStreamContainer
@@ -385,6 +384,11 @@ class LiveStreamPlayer extends PureComponent {
           ? this.panResponder.panHandlers
           : {})}
       >
+        <InteractWhenLoadedConnected
+          isLoading={this.props.isLoading}
+          nodeId={this.props.event.parentId}
+          action={'LIVESTREAM_JOINED'}
+        />
         <PlayheadConsumer>
           {({ currentTime }) => (
             <GoogleCastController

--- a/src/media-player/controls/MiniControls.js
+++ b/src/media-player/controls/MiniControls.js
@@ -122,6 +122,16 @@ class MiniControls extends Component {
     return false;
   }
 
+  get queryVariables() {
+    if (this.props.isLiveStream)
+      return { nodeId: this.props.nodeId, action: 'LIVESTREAM_CLOSED' };
+    return null;
+  }
+
+  get isLiveStream() {
+    return { isLiveStream: this.props.isLiveStream };
+  }
+
   renderMiniControls = ({
     data: {
       mediaPlayer: {
@@ -174,15 +184,8 @@ class MiniControls extends Component {
                   </Mutation>
                 )}
                 <Mutation
-                  mutation={
-                    this.props.isLiveStream ? DISMISS_LIVESTREAM : DISMISS
-                  }
-                  variables={
-                    this.props.isLiveStream && {
-                      nodeId: this.props.nodeId,
-                      action: 'LIVESTREAM_CLOSED',
-                    }
-                  }
+                  mutation={this.isLiveStream ? DISMISS_LIVESTREAM : DISMISS}
+                  variables={this.queryVariables}
                 >
                   {(dismiss) => (
                     <StyledButtonIcon name="close" onPress={() => dismiss()} />

--- a/src/media-player/controls/MiniControls.js
+++ b/src/media-player/controls/MiniControls.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Platform, View, Animated, StyleSheet } from 'react-native';
 import { Mutation, Query } from 'react-apollo';
 import LinearGradient from 'react-native-linear-gradient';
@@ -14,7 +15,13 @@ import {
 
 import { GET_CONTROL_STATE } from '../queries';
 
-import { GO_FULLSCREEN, DISMISS, PLAY, PAUSE } from '../mutations';
+import {
+  GO_FULLSCREEN,
+  DISMISS,
+  DISMISS_LIVESTREAM,
+  PLAY,
+  PAUSE,
+} from '../mutations';
 
 import Seeker from './Seeker';
 
@@ -106,6 +113,11 @@ const MiniSeeker = styled(
 class MiniControls extends Component {
   dismissAnimator = new Animated.Value(0);
 
+  static propTypes = {
+    nodeId: PropTypes.string.isRequired,
+    isLiveStream: PropTypes.bool.isRequired,
+  };
+
   shouldComponentUpdate() {
     return false;
   }
@@ -161,7 +173,17 @@ class MiniControls extends Component {
                     )}
                   </Mutation>
                 )}
-                <Mutation mutation={DISMISS}>
+                <Mutation
+                  mutation={
+                    this.props.isLiveStream ? DISMISS_LIVESTREAM : DISMISS
+                  }
+                  variables={
+                    this.props.isLiveStream && {
+                      nodeId: this.props.nodeId,
+                      action: 'LIVESTREAM_CLOSED',
+                    }
+                  }
+                >
                   {(dismiss) => (
                     <StyledButtonIcon name="close" onPress={() => dismiss()} />
                   )}

--- a/src/media-player/index.js
+++ b/src/media-player/index.js
@@ -83,7 +83,13 @@ const MediaPlayer = () => {
       startsAt: get(liveStream, 'contentItem.events[0].start'),
       endsAt: get(liveStream, 'contentItem.events[0].end'),
     };
-    return <LiveStreamPlayer channelId={channelId} event={event} />;
+    return (
+      <LiveStreamPlayer
+        channelId={channelId}
+        event={event}
+        isLoading={loading}
+      />
+    );
   }
 
   return <FullscreenPlayer />;

--- a/src/media-player/mutations.js
+++ b/src/media-player/mutations.js
@@ -42,6 +42,15 @@ const DISMISS = gql`
   }
 `;
 
+const DISMISS_LIVESTREAM = gql`
+  mutation($nodeId: ID!, $action: InteractionAction!) {
+    mediaPlayerUpdateState(isPlaying: false, isVisible: false) @client
+    interactWithNode(nodeId: $nodeId, action: $action) {
+      success
+    }
+  }
+`;
+
 const PAUSE_AND_RESTART = gql`
   mutation pause {
     mediaPlayerUpdateState(isPlaying: false) @client
@@ -104,6 +113,7 @@ export {
   PLAY,
   PAUSE,
   DISMISS,
+  DISMISS_LIVESTREAM,
   EXIT_FULLSCREEN,
   UPDATE_PLAYHEAD,
   MUTE,

--- a/src/media-player/mutations.js
+++ b/src/media-player/mutations.js
@@ -51,6 +51,14 @@ const DISMISS_LIVESTREAM = gql`
   }
 `;
 
+const JOIN_LIVESTREAM = gql`
+  mutation($nodeId: ID!) {
+    interactWithNode(nodeId: $nodeId, action: LIVESTREAM_JOINED) {
+      success
+    }
+  }
+`;
+
 const PAUSE_AND_RESTART = gql`
   mutation pause {
     mediaPlayerUpdateState(isPlaying: false) @client
@@ -122,4 +130,5 @@ export {
   HIDE_VIDEO,
   CAST_CONNECTED,
   CAST_DISCONNECTED,
+  JOIN_LIVESTREAM,
 };


### PR DESCRIPTION
This PR adds interactions that are reported to Rock when a user joins and closes a live stream.

TO TEST:
1. Make sure you are on `track-interactions` branch for both the app and api.
2. Set your app .env to point at dev rock. `ROCK_API=https://dev-rock.christfellowship.church/`.
3. Fire up your sim and click on the `Test 24 Hour Live Stream` event. When you click on the `play` button after 10 seconds the `LIVESTREAM_JOINED` interaction should fire and you should see that reflected in the interactions in Rock [Apollos Content Item - 7565](https://dev-rock.christfellowship.church/page/664?ComponentId=169206)
4. If you minimize and then close the mini-player the `LIVESTREAM_CLOSED` interaction will be add to Rock.

![image](https://user-images.githubusercontent.com/2528817/95626897-cbe68900-0a40-11eb-85d1-611ad4840f34.png)

 _Note:_ You can test this on the prod Rock instance. You just have to track down the content item you are testing  under `Interactions > Apollos App - Content Channel Item` in Rock.

API PR needed: https://github.com/christfellowshipchurch/apollos-api/pull/138