### PR TITLE
[Chat] Update how chatChannelId is resolved

### DIFF
--- a/src/group-single/GroupChatButton.js
+++ b/src/group-single/GroupChatButton.js
@@ -2,16 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { styled, Button, NavigationService } from '@apollosproject/ui-kit';
 
-import { useFeatureFlag } from '../hooks';
-
 const StyledButton = styled(({ theme }) => ({
   marginBottom: theme.sizing.baseUnit,
 }))(Button);
 
 const GroupChatButton = ({ channelId, groupName }) => {
-  const { enabled } = useFeatureFlag({ key: 'GROUP_CHAT' });
-
-  if (!enabled || !channelId) {
+  if (!channelId) {
     return null;
   }
 

--- a/src/group-single/GroupSingle.js
+++ b/src/group-single/GroupSingle.js
@@ -145,7 +145,7 @@ class GroupSingle extends PureComponent {
     const videoCall = get(content, 'videoCall', {});
     const parentVideoCall = get(content, 'parentVideoCall', {});
     const avatars = get(content, 'avatars', []);
-    const channelId = get(content, 'chatChannelId', null);
+    const channelId = get(content, 'streamChatChannel.channelId', null);
 
     const getNotes = () => {
       const hasParentVideoCall = parentVideoCall && parentVideoCall.link;

--- a/src/group-single/getGroup.js
+++ b/src/group-single/getGroup.js
@@ -21,7 +21,10 @@ export const GROUP_ITEM_FRAGMENT = gql`
       }
     }
     avatars
-    chatChannelId
+    streamChatChannel {
+      id
+      channelId
+    }
   }
 `;
 


### PR DESCRIPTION
# Changes
- Updates **Event** and **Group** chat to use the new `streamChatChannel` node structure on API
- Update **Group Chat** feature flag mechanism to no longer happen manually client side
- Re-add the **Message Group** button when a group's chat channel ID is resolved

# Tradeoffs/Caveats
There's a known issue, where the back button in a Group Chat takes you to profile instead of back to group's details. Logged issue https://github.com/christfellowshipchurch/apollos-app/issues/182 already.

# Test Instructions
- In your local `the-big-merge` branch api, ensure the `FEATURE_FLAG` values in `config.yml` for `LIVE_STREAM_CHAT` and `GROUP_CHAT` are set to `"LIVE"` and that you're logged in as a user in the testing security group

### Event Chat
**With `LIVE_STREAM_CHAT` feature  ✅ LIVE**
- Open the app and go into a live event
- 🔸 Verify you can see the event's chat

**With `LIVE_STREAM_CHAT` feature ❌  DISABLED**
- Open the app and go into a live event
- 🔸 Verify the event's chat is hidden altogether

### Group Chat
**With `GROUP_CHAT` feature  ✅ LIVE**
- Open the app and go into a group's detail page
- 🔸 Verify you can see a new **Message Group** button
- Tap the **Message Group** button
- 🔸 Verify the app navigates to the full screen Channel view, with the group's name in the title

**With `GROUP_CHAT` feature ❌  DISABLED**
- Open the app and go into a group's detail page
- 🔸 Verify there is no **Message Group** button

# Screenshots
|Feature Flag|✅ LIVE|❌ DISABLED|
|---|---|---|
|**`LIVE_STREAM_CHAT`**|![CleanShot 2020-10-27 at 23 27 28@2x](https://user-images.githubusercontent.com/1812955/97387695-e7f58180-18ac-11eb-95d5-6b51b0ae2f7a.jpg)|![image](https://user-images.githubusercontent.com/1812955/97387715-ee83f900-18ac-11eb-89af-78beb00a888f.png)|
|**`GROUP_CHAT`**|![2020-10-27 23 14 20](https://user-images.githubusercontent.com/1812955/97387735-f6dc3400-18ac-11eb-9a34-81c635e50746.gif)|![CleanShot 2020-10-27 at 23 25 26@2x](https://user-images.githubusercontent.com/1812955/97387741-fa6fbb00-18ac-11eb-9c86-6248e9c489b5.jpg)|

