### PR TITLE
Bugsnag source map generation and upload scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ project.xcworkspace
 
 # CocoaPods
 /ios/Pods/
+
+# Source Maps
+*release.bundle
+*release.bundle.map

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   "scripts": {
     "android": "SIM=\"$($HOME/Library/Android/sdk/emulator/emulator -list-avds | sed -n 1p)\" && $HOME/Library/Android/sdk/emulator/emulator -avd \"${SIM}\" & react-native run-android --appId com.apolloschurch.app --main-activity LaunchActivity",
     "beta": "./scripts/add-packages.sh beta",
+    "bugsnag-release": "yarn bugsnag-release:android && yarn bugsnag-release:ios",
+    "bugsnag-release:android": "yarn generate-source-map:android && yarn upload-source-map:android",
+    "bugsnag-release:ios": "yarn generate-source-map:ios && yarn upload-source-map:ios",
+    "generate-source-map:android": "bash ./scripts/generate-bugsnag-source-map.sh android",
+    "generate-source-map:ios": "bash ./scripts/generate-bugsnag-source-map.sh ios",
     "canary": "./scripts/add-packages.sh canary",
     "codecov": "cat ./coverage/lcov.info | codecov",
     "fixlint": "eslint ./src --fix",
@@ -35,6 +40,8 @@
     "test": "jest",
     "unlink-packages": "rm -rf ./node_modules/@apollosproject/* && ../node_modules/.bin/wml rm all",
     "upgrade": "npx @apollosproject/upgrade-tools upgrade",
+    "upload-source-map:android": "bash ./scripts/upload-bugsnag-source-map.sh android",
+    "upload-source-map:ios": "bash ./scripts/upload-bugsnag-source-map.sh ios",
     "version": "node ../../scripts/update-apollos-version.js && git add apollos.json"
   },
   "dependencies": {

--- a/scripts/generate-bugsnag-source-map.sh
+++ b/scripts/generate-bugsnag-source-map.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+VERSION="$(jq .version package.json)"
+LOG="Generating Source Map version $VERSION for $1"
+
+if [ $VERSION != "" ]
+then
+    if [ $1 == "ios" ] || [ $1 == "android" ]
+    then
+        echo "$LOG"
+        react-native bundle \
+            --platform ios \
+            --dev false \
+            --entry-file index.js \
+            --bundle-output "$1-release.bundle" \
+            --sourcemap-output "$1f-release.bundle.map"
+    else
+        echo "Please use either `ios` or `android` as a parameter"  
+    fi
+else
+    echo "Please make sure there is a valid version in your `package.json`"
+fi

--- a/scripts/upload-bugsnag-source-map.sh
+++ b/scripts/upload-bugsnag-source-map.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+VERSION="$(jq .version package.json)"
+BUGSNAG_KEY="$(cat .env | grep BUGSNAG_KEY= | sed 's/BUGSNAG_KEY=//')"
+LOG="Uploading Source Map version $VERSION for $1"
+
+if [ $VERSION != "" ] && [ $BUGSNAG_KEY != "" ]
+then
+    if [ $1 == "ios" ] || [ $1 == "android" ]
+    then
+        echo "$LOG"
+        curl --http1.1 https://upload.bugsnag.com/react-native-source-map \
+            -F apiKey="$BUGSNAG_KEY" \
+            -F appVersion="$VERSION" \
+            -F dev=false \
+            -F platform="$1" \
+            -F sourceMap="@$1-release.bundle.map" \
+            -F bundle="@$1-release.bundle" \
+            -F projectRoot=`pwd` 
+    else
+        echo "Please use either `ios` or `android` as a parameter"
+    fi
+else
+    # Console error for missing version
+    if [ $VERSION != "" ]
+    then
+        echo "Please make sure there is a valid version in your `package.json`"
+    fi
+    
+    # Console error for missing bugsnag api key
+    if [ $BUGSNAG_KEY != "" ]
+    then
+        echo "Please make sure there is a valid Bugsnag API Key in your `env` named BUGSNAG_KEY"
+    fi
+fi


### PR DESCRIPTION
## DESCRIPTION
Adds 2 new scripts along with a bunch of new commands!

**generate-bugsnag-source-map**: Runs a Bugsnag script to create a source map for the given version of the app
**upload-bugsnag-source-map**: Uploads the source map to Bugsnag

Adds 7 new yarn commands in the `package.json`
**generate-source-map:android**: creates an Android source map
**generate-source-map:ios**: creates an iOS source map

**upload-source-map:android**: uploads the Android source map
**upload-source-map:ios**: uploads the iOS source map

**bugsnag-release:android**: runs `generate-` and `upload-` scripts for android
**bugsnag-release:ios**: runs `generate-` and `upload-` scripts for ios
**bugsnag-release**: runs both `bugsnag-release:android` and `bugsnag-ios`

### 1. What does this PR do, or why is it needed?
Part of our version release flows needs to include uploading JS source maps of our build so that we can more easily track bugs in Bugsnag

### 2. What design trade-offs/decisions were made?
* The script includes references to our Bugsnag API key which is kept in an env, so the script will only run if you have a valid `BUGSNAG_KEY` variable in your project `.env`
* To make the release process easiest, we are pulling in the version number from the project's `package.json` and the easiest way to do that was to use `jq` in the script. Installation instructions can be found [here](https://stedolan.github.io/jq/)
* I'm still brand new to bash scripts, so I added a bunch of console logs, but these could be VASTLY improved over time with color coded messaging for info and warnings. Would love some help around this!

### 3. How do I test this PR?
You can check out Bugsnag to see the source maps that were uploaded. I would prefer we not run the scripts again until the next release.

### 4. What automated tests did you write?
n/a

> The purpose of PR Review is to _improve the quality of the software._
