### PR TITLE
Remove timeout delay for consistency with web

### DIFF
--- a/src/media-player/LiveStreamPlayer.js
+++ b/src/media-player/LiveStreamPlayer.js
@@ -296,14 +296,10 @@ class LiveStreamPlayer extends PureComponent {
 
   componentDidMount() {
     Dimensions.addEventListener('change', this.handleOrientationChanged);
-    this.joinLiveStreamTimeout = setTimeout(
-      () =>
-        this.props.client.mutate({
-          mutation: JOIN_LIVESTREAM,
-          variables: { nodeId: this.props.event.parentId },
-        }),
-      10000
-    );
+    this.props.client.mutate({
+      mutation: JOIN_LIVESTREAM,
+      variables: { nodeId: this.props.event.parentId },
+    });
   }
 
   componentDidUpdate(_, oldState) {
@@ -319,7 +315,6 @@ class LiveStreamPlayer extends PureComponent {
 
   componentWillUnmount() {
     Dimensions.removeEventListener('change', this.handleOrientationChanged);
-    clearTimeout(this.joinLiveStreamTimeout);
   }
 
   chatAnimation = ({ showChat }) => {


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
Undoes a decision I insisted on earlier, which is insist that we wait ~10s before firing the `JOIN_LIVESTREAM` interaction to Rock.
I'm not sure why I insisted on that. And more importantly, to be consistent with the web PR [[LiveStream] LiveStream event join/close interactions](https://github.com/christfellowshipchurch/web-app/pull/216), the timeout needs removed.

We'll err on the generous side for counting `JOIN` interactions.

### 2. What design trade-offs/decisions were made?
None

### 3. How do I test this PR?
Careful code review is probably enough, but, you can open a live event in the app and [verify the interaction shows up immediately on Rock](https://rock.christfellowship.church/page/664?ComponentId=181648).

### 4. What automated tests did you write?
None

## SCREENSHOTS/GIFS
N/A

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, storybook, or apps
- [ ] Assign relevant reviewers
- [ ] Upload GIF(s) of iOS, Android
- [ ] Get one peer approval before merging

## REVIEW:

**Manual QA**

- [ ] QA branch on iOS and ensure it looks/behaves as expected
- [ ] QA branch on Android and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
