### PR TITLE
Stream Chat Provider Updates

### DIFF
--- a/src/context/CurrentUserProvider.js
+++ b/src/context/CurrentUserProvider.js
@@ -1,0 +1,53 @@
+/**
+ * CurrentUserProvider.js
+ *
+ * Author: Caleb Panza
+ * Created: Jun 23, 2021
+ *
+ * Listens to changes in the Current User data and response accordingly
+ */
+
+import { useEffect } from 'react';
+import { isEmpty } from 'lodash';
+import { useCurrentUser } from 'hooks';
+import { useStreamChat } from '../stream-chat';
+
+const CurrentUserProvider = ({ children }) => {
+  const { connectUser, disconnectUser } = useStreamChat();
+  const {
+    authId,
+    firstName,
+    lastName,
+    photo,
+    streamChatToken,
+  } = useCurrentUser();
+
+  useEffect(
+    () => {
+      function connect() {
+        if (isEmpty(authId) || isEmpty(streamChatToken)) return;
+
+        connectUser({
+          userId: authId.split(':')[1],
+          userToken: streamChatToken,
+          userName: `${firstName} ${lastName}`,
+          userImage: photo?.uri,
+        });
+      }
+
+      connect();
+
+      return function cleanup() {
+        disconnectUser();
+      };
+    },
+    [authId, firstName, lastName, photo, streamChatToken]
+  );
+
+  return children;
+};
+
+CurrentUserProvider.propTypes = {};
+CurrentUserProvider.defaultProps = {};
+
+export default CurrentUserProvider;

--- a/src/context/ProvidersStack.js
+++ b/src/context/ProvidersStack.js
@@ -25,6 +25,7 @@ import { StreamChatClientContextProvider } from '../stream-chat';
 import { track, identify } from '../amplitude';
 import { UserFlagsProvider } from '../user-flags';
 import CoreApollosProviders from './CoreApollosProviders';
+import CurrentUserProvider from './CurrentUserProvider';
 import NotificationsProvider from './NotificationsProvider';
 import UniversalLinkRouteProvider from './UniversalLinkRouteProvider';
 
@@ -33,38 +34,40 @@ import UniversalLinkRouteProvider from './UniversalLinkRouteProvider';
 
 const ProvidersStack = (props) => (
   // <AppearanceProvider>
-  <ClientProvider {...props}>
-    <NotificationsProvider
-      oneSignalKey={ApollosConfig.ONE_SIGNAL_KEY}
-      navigate={NavigationService.navigate}
-    >
-      <AuthProvider
-        navigateToAuth={() => NavigationService.navigate('Auth')}
+  <StreamChatClientContextProvider>
+    <ClientProvider {...props}>
+      <NotificationsProvider
+        oneSignalKey={ApollosConfig.ONE_SIGNAL_KEY}
         navigate={NavigationService.navigate}
-        closeAuth={() =>
-          checkOnboardingStatusAndNavigate({
-            client,
-            navigation: NavigationService,
-          })
-        }
       >
-        <AnalyticsProvider
-          trackFunctions={[track]}
-          identifyFunctions={[identify]}
+        <AuthProvider
+          navigateToAuth={() => NavigationService.navigate('Auth')}
+          navigate={NavigationService.navigate}
+          closeAuth={() =>
+            checkOnboardingStatusAndNavigate({
+              client,
+              navigation: NavigationService,
+            })
+          }
         >
-          <CoreApollosProviders {...props}>
-            <UserFlagsProvider>
-              <StreamChatClientContextProvider>
-                <ActionSheetProvider>
-                  <UniversalLinkRouteProvider {...props} />
-                </ActionSheetProvider>
-              </StreamChatClientContextProvider>
-            </UserFlagsProvider>
-          </CoreApollosProviders>
-        </AnalyticsProvider>
-      </AuthProvider>
-    </NotificationsProvider>
-  </ClientProvider>
+          <CurrentUserProvider>
+            <AnalyticsProvider
+              trackFunctions={[track]}
+              identifyFunctions={[identify]}
+            >
+              <CoreApollosProviders {...props}>
+                <UserFlagsProvider>
+                  <ActionSheetProvider>
+                    <UniversalLinkRouteProvider {...props} />
+                  </ActionSheetProvider>
+                </UserFlagsProvider>
+              </CoreApollosProviders>
+            </AnalyticsProvider>
+          </CurrentUserProvider>
+        </AuthProvider>
+      </NotificationsProvider>
+    </ClientProvider>
+  </StreamChatClientContextProvider>
 
   // </AppearanceProvider>
 );

--- a/src/drawer/Logout.js
+++ b/src/drawer/Logout.js
@@ -12,6 +12,7 @@ import {
 } from '@apollosproject/ui-kit';
 
 import { LOGOUT } from '@apollosproject/ui-auth';
+import { useStreamChat } from '../stream-chat';
 
 import { TableView, Cell } from '../ui/TableView';
 
@@ -23,6 +24,7 @@ const VersionText = styled(({ theme }) => ({
 
 const Logout = ({ onLogout }) => {
   const [handleLogout] = useMutation(LOGOUT);
+  const { disconnectUser } = useStreamChat();
 
   return (
     <View>
@@ -35,6 +37,7 @@ const Logout = ({ onLogout }) => {
           title="Log Out"
           onPress={async () => {
             await handleLogout();
+            await disconnectUser();
             // This resets the navigation stack, and the navigates to the first auth screen.
             // This ensures that user isn't navigated to a subscreen of Auth, like the pin entry screen.
             await NavigationService.resetToAuth();

--- a/src/hooks/useCurrentUser.js
+++ b/src/hooks/useCurrentUser.js
@@ -210,6 +210,7 @@ const useCurrentUser = (props) => {
     data,
     ...queryProps,
     id,
+    authId: id,
     ...profile,
     updateProfile,
     updateProfileField,

--- a/src/stream-chat/components/ChatChannelList.js
+++ b/src/stream-chat/components/ChatChannelList.js
@@ -73,6 +73,7 @@ const ChatChannelList = ({ theme }) => {
             setChannel({ channel });
             navigation.navigate('ChatChannelSingle', {
               hideNavigationHeader: true,
+              itemTitle: channel?.data?.name,
             });
           }}
           options={options}

--- a/src/stream-chat/components/NotificationsToggle.js
+++ b/src/stream-chat/components/NotificationsToggle.js
@@ -36,7 +36,8 @@ const StyledIcon = withTheme(({ theme }) => ({
 // ===========================
 
 const NotificationsToggle = () => {
-  const { channel, userId } = useStreamChat();
+  const { channel, chatClient } = useStreamChat();
+  const userId = chatClient?.user?.id;
   const muteNotifications = Array.isArray(channel?.data?.muteNotifications)
     ? channel?.data?.muteNotifications
     : [];
@@ -50,7 +51,7 @@ const NotificationsToggle = () => {
 
     await channel.updatePartial({
       set: {
-        muteNotifications: newMuted,
+        muteNotifications: newMuted.filter((id) => !!id),
       },
     });
 

--- a/src/stream-chat/index.js
+++ b/src/stream-chat/index.js
@@ -1,4 +1,8 @@
-export { ChatChannel, ChatChannelList } from './components';
+export {
+  ChatChannel,
+  ChatChannelList,
+  NotificationsToggle,
+} from './components';
 export { StreamChatClientContextProvider, useStreamChat } from './context';
 export {
   default as StreamChatOverlayProvider,

--- a/src/stream-chat/screens/ChatChannelSingle.js
+++ b/src/stream-chat/screens/ChatChannelSingle.js
@@ -11,6 +11,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { compose } from 'recompose';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRoute } from '@react-navigation/native';
 
 import LinearGradient from 'react-native-linear-gradient';
 import {

--- a/src/tabs/HeaderButtons.js
+++ b/src/tabs/HeaderButtons.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   useNavigation,
   DrawerActions,
@@ -11,8 +11,10 @@ import {
   Icon,
   withTheme,
   styled,
+  UIText,
 } from '@apollosproject/ui-kit';
 
+import { isOwnUser } from 'stream-chat';
 import { useStreamChat } from '../stream-chat';
 
 const IconsContainer = styled(({ theme }) => ({
@@ -28,6 +30,30 @@ const ItemLeft = styled(({ theme }) => ({
   paddingRight: theme.sizing.baseUnit * 0.5,
 }))(View);
 
+const RelativePosition = styled(({ theme }) => ({
+  position: 'relative',
+}))(View);
+
+const UnreadCountSpacing = styled(({ theme }) => ({
+  position: 'absolute',
+  top: -3,
+  right: -5,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  minHeight: 16,
+  minWidth: 16,
+  padding: 2,
+  backgroundColor: theme.colors.alert,
+  borderRadius: 99,
+}))(View);
+
+const UnreadCountText = styled(({ theme }) => ({
+  color: theme.colors.white,
+  fontSize: 10,
+  lineHeight: 0,
+}))(UIText);
+
 const StyledIcon = withTheme(({ theme }) => ({
   size: 24,
   fill: theme.colors.text.tertiary,
@@ -35,10 +61,7 @@ const StyledIcon = withTheme(({ theme }) => ({
 
 const NotificationIcon = withTheme(({ theme, unreadCount }) => ({
   size: 24,
-  name:
-    Number.isInteger(unreadCount) && unreadCount > 0
-      ? 'notification-alert'
-      : 'bell',
+  name: 'bell',
   fill:
     Number.isInteger(unreadCount) && unreadCount > 0
       ? theme.colors.alert
@@ -47,12 +70,45 @@ const NotificationIcon = withTheme(({ theme, unreadCount }) => ({
 
 export const NotificationCenterIconConnected = () => {
   const navigation = useNavigation();
-  const { unreadCount } = useStreamChat();
+  const { chatClient } = useStreamChat();
+  const [unreadCount, setUnreadCount] = useState(0);
+  const maxUnreadCount = 9;
+
+  useEffect(
+    () => {
+      const user = chatClient?.user;
+      setUnreadCount(isOwnUser(user) ? user.total_unread_count : 0);
+
+      const listener = chatClient?.on((e) => {
+        if (Number.isInteger(e.total_unread_count)) {
+          setUnreadCount(e.total_unread_count);
+        }
+      });
+
+      return () => {
+        if (listener) {
+          listener.unsubscribe();
+        }
+      };
+    },
+    [chatClient]
+  );
 
   return (
     <TouchableScale onPress={() => navigation.navigate('ChatChannelList')}>
       <ItemLeft>
-        <NotificationIcon unreadCount={unreadCount} />
+        <RelativePosition>
+          <NotificationIcon unreadCount={unreadCount} />
+          {unreadCount > 0 && (
+            <UnreadCountSpacing>
+              <UnreadCountText bold>
+                {unreadCount > maxUnreadCount
+                  ? `${maxUnreadCount}+`
+                  : unreadCount}
+              </UnreadCountText>
+            </UnreadCountSpacing>
+          )}
+        </RelativePosition>
       </ItemLeft>
     </TouchableScale>
   );
@@ -71,15 +127,11 @@ export const DrawerButton = () => {
   );
 };
 
-const HeaderButtons = () => {
-  const isFocused = useIsFocused();
-
-  return (
-    <IconsContainer>
-      {isFocused && <NotificationCenterIconConnected />}
-      <DrawerButton />
-    </IconsContainer>
-  );
-};
+const HeaderButtons = () => (
+  <IconsContainer>
+    <NotificationCenterIconConnected />
+    <DrawerButton />
+  </IconsContainer>
+);
 
 export default HeaderButtons;

--- a/src/tabs/index.js
+++ b/src/tabs/index.js
@@ -19,7 +19,7 @@ import HeaderButtons from './HeaderButtons';
 const { Navigator, Screen } = createBottomTabNavigator();
 
 const TabNavigator = (props) => (
-  <Navigator {...props}>
+  <Navigator {...props} lazy>
     <Screen
       name="Home"
       component={Home}


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
There was a bug reported that the In App Notification indicator was not accurately displaying when a Notification was read/unread. While investigating, it appeared that there was a conflict between multiple instances of the Stream `chatClient` being created, each of which is returning different data for the `total_unread_count`.

This PR seeks to resolve that problem by reworking the Global State Provider for Stream Chat.

### 2. What design trade-offs/decisions were made?
**Global State:** Stream Chat now has a new global state provider which sits at the root of the application. This Provider _only_ provides the current context of Stream. This includes:
* chatClient object
* Connection Status
* Active Channel
* Methods to update/change these values
* Connection/Disconnection methods to trigger new user states

**Current User Provider:** This new provider sits below the AuthProvider and listens for changes in User Login State. From there, it triggers the appropriate methods provided by the Stream Chat Client hook to update the user state

### 3. What is the outcome of this update?
* User logs in, logs out, and logs in as a new user and the new user is reflected accurately in Stream
* Performance and stability enhancements as we adhere closer to the preferred Stream implementation according to their API
* As you receive and read messages, the Notification Bell will accurately reflect the current user state across all apps
* New little "unread count" indicator as a part of the Bell Icon

### Closes Issues
[CFDP-1437]

### Related/Impacted Issues
[CFDP-1293]
[CFDP-1287]
[CFDP-1285]

[CFDP-1437]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1437