### PR TITLE
Patch stream chat connection

### DIFF
--- a/src/context/CurrentUserProvider.js
+++ b/src/context/CurrentUserProvider.js
@@ -37,9 +37,9 @@ const CurrentUserProvider = ({ children }) => {
 
       connect();
 
-      return function cleanup() {
-        disconnectUser();
-      };
+      // return function cleanup() {
+      //   disconnectUser();
+      // };
     },
     [authId, firstName, lastName, photo, streamChatToken]
   );

--- a/src/context/NotificationsProvider.js
+++ b/src/context/NotificationsProvider.js
@@ -90,7 +90,6 @@ class NotificationsInit extends Component {
   }
 
   navigate = (rawUrl) => {
-    console.log({ rawUrl });
     if (!rawUrl) return;
     this.props.routeLink(rawUrl);
   };

--- a/src/context/UniversalLinkRouteProvider.js
+++ b/src/context/UniversalLinkRouteProvider.js
@@ -18,9 +18,6 @@ const UniversalLinkRouteProvider = ({ children }) => {
 
   const handleAppStateChange = async () => {
     const initial = await Linking.getInitialURL();
-    console.log({ initial });
-
-    return;
     if (initial !== null && !initialised) {
       setInitialised(true);
       // app was opened by a Universal Link

--- a/src/group-single/Group/Actions.js
+++ b/src/group-single/Group/Actions.js
@@ -35,6 +35,7 @@ const GET_ACTION_PARTS = gql`
         streamChatChannel {
           id
           channelId
+          channelType
         }
       }
 
@@ -69,7 +70,7 @@ const renderChatButton = ({ id, channelId, name, navigation, theme }) => {
     // todo : temporary hack until we can get the OverlayProvider working correctly
     navigation.goBack(null);
     navigation.navigate('ChatChannelSingle', {
-      title: name,
+      itemTitle: name,
     });
   };
 
@@ -210,8 +211,11 @@ const Actions = ({ id, name, theme }) => {
           },
         });
 
-        if (setChannel) {
-          setChannel({ relatedNodeId: id });
+        if (setChannel && streamChat?.channelId && streamChat?.channelType) {
+          setChannel({
+            channelId: streamChat.channelId,
+            channelType: streamChat.channelType,
+          });
         }
       }
     },

--- a/src/group-single/Group/index.js
+++ b/src/group-single/Group/index.js
@@ -117,7 +117,7 @@ const Group = ({ id, content, loading }) => {
         </PaddedView>
 
         <PaddedView horizontal={false}>
-          <Actions id={id} />
+          <Actions id={id} name={content.title} />
         </PaddedView>
 
         <PaddedView vertical={false}>

--- a/src/hooks/useLinkRouter.js
+++ b/src/hooks/useLinkRouter.js
@@ -22,8 +22,6 @@ const deepLink = (rawUrl, navigationOptions) => {
   const route = url.pathname.substring(1);
   const args = querystring.parse(url.query);
 
-  console.log({ NavigationService });
-
   NavigationService.navigate(route, { ...args, ...navigationOptions });
 };
 

--- a/src/stream-chat/components/ChatChannelList.js
+++ b/src/stream-chat/components/ChatChannelList.js
@@ -70,7 +70,6 @@ const ChatChannelList = ({ theme }) => {
           HeaderNetworkDownIndicator={() => null}
           maxUnreadCount={99}
           onSelect={(channel) => {
-            console.log({ channel });
             setChannel({ channel });
             navigation.navigate('ChatChannelSingle', {
               hideNavigationHeader: true,

--- a/src/stream-chat/hooks/index.js
+++ b/src/stream-chat/hooks/index.js
@@ -1,2 +1,3 @@
 export { default as useStreamChatChannel } from './useStreamChatChannel';
 export { default as useStreamChatClient } from './useStreamChatClient';
+export { ConnectionStatus } from './useStreamChatClient';

--- a/src/stream-chat/screens/ChatChannelSingle.js
+++ b/src/stream-chat/screens/ChatChannelSingle.js
@@ -22,6 +22,7 @@ import {
 } from '@apollosproject/ui-kit';
 import { ChatChannel } from '../components';
 import { useStreamChat } from '../context';
+import { ConnectionStatus } from '../hooks';
 
 const BackgroundView = compose(
   withTheme(({ theme }) => ({
@@ -34,19 +35,23 @@ const BackgroundView = compose(
 
 const ChatChannelSingle = (props) => {
   const params = props?.route?.params;
-  const { setChannel, channel } = useStreamChat();
+  const { connectionStatus, setChannel, channel } = useStreamChat();
 
   // note : not the most elegant solution, but it's the easiest way to handle deep linking with push notifications
   useEffect(
     () => {
-      if (params?.streamChannelId && params?.streamChannelType) {
+      if (
+        ConnectionStatus.CONNECTED &&
+        params?.streamChannelId &&
+        params?.streamChannelType
+      ) {
         setChannel({
           channelId: params?.streamChannelId,
           channelType: params?.streamChannelType,
         });
       }
     },
-    [params]
+    [params, connectionStatus]
   );
 
   return (


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
Found some additional connection/disconnection issues inside of the Stream Chat set up. Also updates some of the Group rendering logic to better adhere to the new Provider structure.

### 2. What design trade-offs/decisions were made?
Removes the ability to query for a Chat Channel from a nodeId from the `StreamChatClientContext`. This is due to the Apollo Client not being accessible inside of this context. I also removed all "cleanup" functions cause it looked like there are quite a few instances in which the cleanup was running and disconnected the user from Stream.

This re-introduces the `"consecutive calls to chatClient.connect"` warning, but it seems to be inconsequential from the testing so far.

### Related Issues
[CFDP-1285]
[CFDP-1437]

[CFDP-1285]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1285
[CFDP-1437]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1437