### PR TITLE
Notification badge update

### DIFF
--- a/ios/ChristFellowship.xcodeproj/project.pbxproj
+++ b/ios/ChristFellowship.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 				"${PODS_ROOT}/Target Support Files/Pods-ChristFellowship/Pods-ChristFellowship-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
 				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTC.framework",
+				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTCScreenShare.framework",
 				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTCResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
@@ -635,6 +636,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTC.framework",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTCScreenShare.framework",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTCResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",
@@ -655,6 +657,7 @@
 				"${PODS_ROOT}/Target Support Files/Pods-ChristFellowship-ChristFellowshipTests/Pods-ChristFellowship-ChristFellowshipTests-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RNImageCropPicker/QBImagePicker.bundle",
 				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTC.framework",
+				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTCScreenShare.framework",
 				"${PODS_ROOT}/../../node_modules/react-native-zoom-bridge/ios/libs/MobileRTCResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/TOCropViewController/TOCropViewControllerBundle.bundle",
@@ -665,6 +668,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/QBImagePicker.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTC.framework",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTCScreenShare.framework",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MobileRTCResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/TOCropViewControllerBundle.bundle",

--- a/ios/ChristFellowship/Info.plist
+++ b/ios/ChristFellowship/Info.plist
@@ -111,5 +111,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>OneSignal_disable_badge_clearing</key>
+	<true/>
 </dict>
 </plist>

--- a/src/context/AppBadgeProvider.js
+++ b/src/context/AppBadgeProvider.js
@@ -51,22 +51,24 @@ export const AppBadgeProvider = (props) => {
 
   useEffect(
     () => {
-      const user = chatClient?.user;
-      setBadge(isOwnUser(user) ? user.total_unread_count : 0);
+      if (badgeRef) {
+        const user = chatClient?.user;
+        setBadge(isOwnUser(user) ? user.total_unread_count : 0);
 
-      const listener = chatClient?.on((e) => {
-        if (Number.isInteger(e.total_unread_count)) {
-          setBadge(e.total_unread_count);
-        }
-      });
+        const listener = chatClient?.on((e) => {
+          if (Number.isInteger(e.total_unread_count)) {
+            setBadge(e.total_unread_count);
+          }
+        });
 
-      return () => {
-        if (listener) {
-          listener.unsubscribe();
-        }
-      };
+        return () => {
+          if (listener) {
+            listener.unsubscribe();
+          }
+        };
+      }
     },
-    [chatClient]
+    [chatClient, badgeRef]
   );
 
   return (

--- a/src/context/NotificationsProvider.js
+++ b/src/context/NotificationsProvider.js
@@ -83,9 +83,7 @@ class NotificationsInit extends Component {
 
   componentWillUnmount() {
     Linking.removeEventListener('url');
-    OneSignal.removeEventListener('received');
-    OneSignal.removeEventListener('opened');
-    OneSignal.removeEventListener('ids');
+    OneSignal.clearHandlers();
   }
 
   navigate = (rawUrl) => {

--- a/src/tabs/HeaderButtons.js
+++ b/src/tabs/HeaderButtons.js
@@ -16,6 +16,7 @@ import {
 
 import { isOwnUser } from 'stream-chat';
 import { useStreamChat } from '../stream-chat';
+import { useAppBadge } from '../context/AppBadgeProvider';
 
 const IconsContainer = styled(({ theme }) => ({
   flexDirection: 'row',
@@ -70,41 +71,18 @@ const NotificationIcon = withTheme(({ theme, unreadCount }) => ({
 
 export const NotificationCenterIconConnected = () => {
   const navigation = useNavigation();
-  const { chatClient } = useStreamChat();
-  const [unreadCount, setUnreadCount] = useState(0);
+  const { badge } = useAppBadge();
   const maxUnreadCount = 9;
-
-  useEffect(
-    () => {
-      const user = chatClient?.user;
-      setUnreadCount(isOwnUser(user) ? user.total_unread_count : 0);
-
-      const listener = chatClient?.on((e) => {
-        if (Number.isInteger(e.total_unread_count)) {
-          setUnreadCount(e.total_unread_count);
-        }
-      });
-
-      return () => {
-        if (listener) {
-          listener.unsubscribe();
-        }
-      };
-    },
-    [chatClient]
-  );
 
   return (
     <TouchableScale onPress={() => navigation.navigate('ChatChannelList')}>
       <ItemLeft>
         <RelativePosition>
-          <NotificationIcon unreadCount={unreadCount} />
-          {unreadCount > 0 && (
+          <NotificationIcon unreadCount={badge} />
+          {badge > 0 && (
             <UnreadCountSpacing>
               <UnreadCountText bold>
-                {unreadCount > maxUnreadCount
-                  ? `${maxUnreadCount}+`
-                  : unreadCount}
+                {badge > maxUnreadCount ? `${maxUnreadCount}+` : badge}
               </UnreadCountText>
             </UnreadCountSpacing>
           )}


### PR DESCRIPTION
### About
* Updates an error with OneSignal not using the updated SDK reference for removing listeners
* Updates the `useEffect` for setting the Badge Icon to ensure that the `badgeRef` is set before interacting
* Sets OneSignal to _not_ automatically remove the badge (we want to set this manually)
* Uses the Badge to set the in-app Notification Badge so that the App Badge and and In-App Badge are always in sync (this has appeared to resolve the issue with syncing between tabs

### Test Instructions
Load up the app and send some test notifications using the Chat feature. You should notice the Home Screen and In App Badges match as you receive/read messages

### Screenshots
| In App | Home Screen |
| --- | --- |
| <img width="300" alt="Screen Shot 2021-07-06 at 4 57 55 PM" src="https://user-images.githubusercontent.com/45076058/124666001-6d3d2700-de7b-11eb-8c0f-5151b0ef9a13.png"> | <img width="300" alt="Screen Shot 2021-07-06 at 4 57 59 PM" src="https://user-images.githubusercontent.com/45076058/124666004-6f06ea80-de7b-11eb-8772-c3295a548a69.png"> |

### Closes Tickets
[CFDP-1437]

### Related Tickets
[CFDP-1287]

[CFDP-1437]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1437